### PR TITLE
Build real noarch packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,7 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        include:
-          - { platform: unix, os: ubuntu-latest }
-          - { platform: win, os: windows-latest }
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:

--- a/matryoshka/recipe.yaml
+++ b/matryoshka/recipe.yaml
@@ -1,7 +1,6 @@
 context:
   name: "matryoshka"
   version: "0.1.0"
-  build_number: 0
 
 package:
   name: "typst-${{ name }}"
@@ -12,23 +11,14 @@ source:
   sha256: 2f7a55c965846df53cd2f3ebcf381214056d28958ef78e49fe34ded79c30afb5
 
 build:
-  number: ${{ build_number }}
+  number: 1
   noarch: generic
-  string: ${{ hash }}_${{ build_number }}_${{ 'win' if win else 'unix' }}
   script:
     content:
       - cargo build --locked --release --target wasm32-unknown-unknown
-      - if: not win
-        then:
-          - mkdir -p "$PREFIX/share/typst/packages/typst-forge/${{ name }}/${{ version }}"
-          - cp typst.toml README.md lib.typ target/wasm32-unknown-unknown/release/matryoshka.wasm
-              "$PREFIX/share/typst/packages/typst-forge/${{ name }}/${{ version }}"
-        else:
-          - mkdir "%PREFIX%\Library\share\typst\packages\typst-forge\${{ name }}\${{ version }}"
-          - copy typst.toml "%PREFIX%\Library\share\typst\packages\typst-forge\${{ name }}\${{ version }}"
-          - copy README.md "%PREFIX%\Library\share\typst\packages\typst-forge\${{ name }}\${{ version }}"
-          - copy lib.typ "%PREFIX%\Library\share\typst\packages\typst-forge\${{ name }}\${{ version }}"
-          - copy target\wasm32-unknown-unknown\release\matryoshka.wasm "%PREFIX%\Library\share\typst\packages\typst-forge\${{ name }}\${{ version }}"
+      - mkdir -p "$PREFIX/share/typst/packages/typst-forge/${{ name }}/${{ version }}"
+      - cp typst.toml README.md lib.typ target/wasm32-unknown-unknown/release/matryoshka.wasm
+          "$PREFIX/share/typst/packages/typst-forge/${{ name }}/${{ version }}"
 
 tests:
   - script:
@@ -42,10 +32,9 @@ requirements:
   build:
     - rust
     - rust-std-wasm32-unknown-unknown
-    - __${{ 'win' if win else 'unix' }}
+    - __unix
   run:
     - typst >=0.12.0rc1
-    - __${{ 'win' if win else 'unix' }}
 
 about:
   repository: https://github.com/freundTech/typst-matryoshka

--- a/moderner-cv/recipe.yaml
+++ b/moderner-cv/recipe.yaml
@@ -1,7 +1,6 @@
 context:
   name: "moderner-cv"
   version: "0.1.0"
-  build_number: 0
 
 package:
   name: "typst-${{ name }}"
@@ -14,22 +13,13 @@ source:
     - 0001-Change-template-file-import-to-typst-forge.patch
 
 build:
-  number: ${{ build_number }}
+  number: 1
   noarch: generic
-  string: ${{ hash }}_${{ build_number }}_${{ 'win' if win else 'unix' }}
   script:
     content:
-      - if: not win
-        then:
-          - mkdir -p "$PREFIX/share/typst/packages/typst-forge/${{ name }}/${{ version }}"
-          - cp -r typst.toml README.md lib.typ template/
-              "$PREFIX/share/typst/packages/typst-forge/${{ name }}/${{ version }}"
-        else:
-          - mkdir "%PREFIX%\Library\share\typst\packages\typst-forge\${{ name }}\${{ version }}"
-          - copy typst.toml "%PREFIX%\Library\share\typst\packages\typst-forge\${{ name }}\${{ version }}"
-          - copy README.md "%PREFIX%\Library\share\typst\packages\typst-forge\${{ name }}\${{ version }}"
-          - copy lib.typ "%PREFIX%\Library\share\typst\packages\typst-forge\${{ name }}\${{ version }}"
-          - xcopy /E template\ "%PREFIX%\Library\share\typst\packages\typst-forge\${{ name }}\${{ version }}\template\"
+      - mkdir -p "$PREFIX/share/typst/packages/typst-forge/${{ name }}/${{ version }}"
+      - cp -r typst.toml README.md lib.typ template/
+          "$PREFIX/share/typst/packages/typst-forge/${{ name }}/${{ version }}"
 
 tests:
   - script:
@@ -39,10 +29,9 @@ tests:
 
 requirements:
   build:
-    - __${{ 'win' if win else 'unix' }}
+    - __unix
   run:
     - typst >=0.12.0rc1
-    - __${{ 'win' if win else 'unix' }}
 
 about:
   repository: https://github.com/pavelzw/moderner-cv


### PR DESCRIPTION
This breaks backwards compatibility and depends on https://github.com/conda-forge/typst-feedstock/pull/28 being merged. We accept this breaking change as typst supporting conda packaged packages is still an rc.