### PR TITLE
Add task to get hash

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -6,6 +6,7 @@ platforms = ["linux-64", "linux-aarch64", "win-64", "osx-64", "osx-arm64"]
 
 [feature.build.tasks]
 build = "rattler-build build -c conda-forge -c https://prefix.dev/typst-forge --recipe "
+get-hash = { args = ["url"], cmd = "curl -sL \"{{ url }}\" -o - | shasum -a 256 | cut -d ' ' -f 1" }
 
 [feature.build.dependencies]
 rattler-build = ">=0.24.0"


### PR DESCRIPTION
To make it easier to find the SHA256, I've made a task that fetches the SHA256. It is run this way:
```
pixi run get-hash <url-to-package>
```

So example:
```
pixi run get-hash https://github.com/roaldarbol/academicv/archive/refs/tags/v1.1.1.tar.gz
```

Solves #35.